### PR TITLE
Fix regex when setting multiple permissions

### DIFF
--- a/Public/New-CrushUser.ps1
+++ b/Public/New-CrushUser.ps1
@@ -590,7 +590,7 @@ Param(
             foreach($item in $VFSItems) {
                 if($item -match $regexVFSItems) {
                     $item = $item -replace '<\/vfs_items>$', '' # Regex TrimEnd
-                    $item = $item -replace '^<\?xml version="1\.0" encoding="UTF-8"\?><vfs_items type="properties">i?', '' # Regex TrimStart
+                    $item = $item -replace '^<\?xml version="1\.0" encoding="UTF-8"\?><vfs_items type="vector">i?', '' # Regex TrimStart
                     $MultipleVFSItems += $item
                 } else {
                     $MultipleVFSItems += $item

--- a/Public/Set-CrushUser.ps1
+++ b/Public/Set-CrushUser.ps1
@@ -625,7 +625,7 @@ Param(
             foreach($item in $Permissions) {
                 if($item -match $regexPermissions) {
                     $item = $item -replace '<\/VFS>$', '' # TrimEnd
-                    $item = $item -replace '^<\?xml version="1\.0" encoding="UTF-8"\?><permissions type="properties">i?', '' #TrimStart
+                    $item = $item -replace '^<\?xml version="1\.0" encoding="UTF-8"\?><permissions type="vector">i?', '' #TrimStart
                     $MultiplePermissions += $item
                 } else {
                     $MultiplePermissions += $item


### PR DESCRIPTION
The regex used for trimming multiple VFSItems is currently set to look for `type="properties"`, though in the `new-crushvfsitem` function it's explicitly set as `type="vector"`. This causes the regex to skip trimming and the final request to be malformed. Any call to `set-crushuser` or `new-crushuser` that uses  multiple VFSitems as an argument was not functioning properly. No error is returned by CrushFTP in these cases, but users won't be correctly created nor updated. With this fix, users with multiple VFSItems can be correctly created and modified.

Also, I'm using CrushFTP 10 so it appears to be (at least mostly) compatible